### PR TITLE
small typo fix.code snippet for `server.js:12`

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ const generateId = require('./lib/generate-id');
 app.use(express.static('static'));
 app.use(bodyParser.urlencoded({ extended: true }));
 
-app.set('view engine', 'handlebars');
+app.set('view engine', 'jade');
 
 app.set('port', process.env.PORT || 3000);
 app.locals.title = 'Pizza Express';


### PR DESCRIPTION
Earlier in the tutorial, we had decided to use "jade" and not "handlebars".
