### PR TITLE
Make change to Express static pages setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Having a directory for static assets is incredibly useful because we'll probably
 app.use(express.static('static'));
 ```
 
-By default, `express.static` serves everything in the `static` directory from the root. That said, it doesn't serve `index.html` if no file name is given—like Apache or some other static asset web server would. We would likely combine both of these approaches because Express won't serve `index.html` at `/` otherwise.
+By default, `express.static` serves everything in the `static` directory from the root. While Express will automatically serve index.html as '/' we'll be explicit to get in the habit.
 
 At this moment, your `server.js` should look something like the code sample below and your tests should be passing.
 


### PR DESCRIPTION
I don't know if this is new to express, but it automatically defaults the '/'  path to 'index.html' if you have the line 
`app.use(express.static('static'));` and a index.html file in your static directory. I made changes to lesson plan accordingly. 
@stevekinney
@rrgayhart
